### PR TITLE
QR: Adjustments for recent XT update

### DIFF
--- a/src/css/Quickreply.css
+++ b/src/css/Quickreply.css
@@ -2,21 +2,28 @@
 #qr {
   box-shadow: none !important;
   border-radius: 0 !important;
-  box-shadow: none !important;
+}
+:root:not(.vertical-qr) #qr .move {
+  min-width: 302px;
 }
 #qr .close {
   padding: 2px 3px 2px 4px !important;
 }
 #qr .riceCheck,
 #qr input[type=checkbox] {
-  margin: 0 4px 1px!important;
+  margin: 0 4px 1px;
   vertical-align: baseline;
   position: relative;
   top: 3px;
 }
+:root.fourchan-xt #qr .move .riceCheck,
+:root.fourchan-xt #qr .move input[type=checkbox] {
+  margin: 0 4px 2px;
+  top: 2px;
+}
 #qr-filename-container .riceCheck,
 #qr-filename-container input[type=checkbox] {
-  margin: 0 0 1px!important;
+  margin: 0 0 1px;
 }
 #qr-file-button,
 #qr input[type='submit'] {
@@ -120,12 +127,17 @@
   transform: translateX(100%);
 }
 :root.vertical-qr #qr .move {
+  display: block;
   position: absolute;
   width: 105px;
   cursor: default;
   padding: 2px 0 2px 2px;
   text-align: center;
   bottom: 88px;
+}
+/* Remove flex from qr label in XT */
+:root.vertical-qr #qr .move label {
+  display: inline;
 }
 :root.vertical-qr #qr:hover .move {
   transition: opacity .42s linear;


### PR DESCRIPTION
In relation to [XT/9b3a928](https://github.com/TuxedoTako/4chan-xt/commit/9b3a928269394fe491e9cdfec5bdadb6bfa600f6), QR box was changed to add flex elements, which messed with the positioning of some elements when using Stylechan.
- Adjusted position for the top checkbox.
- Removed flex when using Vertical QR.

Additionally:
- Removed !important tags as they don't seem to be needed, and a dupe box-shadow
- Set min-width for the move element, as this will prevent it from snapping slightly bigger when using normal auto-hide.