### PR TITLE
Some new features, fixes, reworks

### DIFF
--- a/src/css/Catalog.css
+++ b/src/css/Catalog.css
@@ -13,24 +13,6 @@
 #threads {
   padding: 10px 0 !important;
 }
-/* Catalog Link */
-.pages.cataloglink {
-  margin-left: 12px;
-  border-radius: 3px;
-}
-.pages.cataloglink a,
-input[value='Next'],
-input[value='Previous'] {
-  color: " + $SS.theme.textColor.hex + " !important;
-  font-weight: bold;
-}
-.pages.cataloglink a:hover,
-input[value='Next']:hover,
-input[value='Previous']:hover {
-  color: " + $SS.theme.textColor.hex + " !important;
-  opacity: 0.7 !important;
-  transition: opacity .3s ease-in 0s;
-}
 /* Catalog Comment */
 :root.catalog-justify .teaser,
 :root.catalog-justify .catalog-post > .postMessage {

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -146,7 +146,7 @@ body.is_catalog .panel,
 #post-preview,
 #tegaki,
 .boxbar,
-:root.op-background .postContainer.opContainer,
+:root.op-background .op:not(.inline .op),
 .flashListing tr:nth-of-type(2n+1):not(.highlightPost),
 .dd-menu ul,
 :root.catalog-hover-expand .catalog-container:hover > .post {
@@ -238,25 +238,25 @@ hr {
 }
 /* Borders */
 .reply,
-:root.op-background .postContainer.opContainer,
+:root.op-background .op:not(#qp .op, .inline .op),
 .dd-menu ul {
   border-width: 0 1px 1px 0;
   border-style: solid;
 }
 :root.borders-all .reply,
-:root.borders-all.op-background .postContainer.opContainer {
+:root.borders-all.op-background .op {
   border-width: 1px !important;
 }
 :root.borders-none .reply,
-:root.borders-none.op-background .postContainer.opContainer {
-  border: 0;
+:root.borders-none.op-background .op {
+  border: 0 !important;
 }
 #menu,
 .catalog-thumb {
   border-radius: 0 !important;
 }
 :root.rounded-corners .reply,
-:root.rounded-corners.op-background .postContainer.opContainer,
+:root.rounded-corners.op-background .op,
 :root.rounded-corners .dialog:not(#header-bar),
 :root.rounded-corners .inline,
 :root.rounded-corners #thread-stats
@@ -286,7 +286,7 @@ hr {
   border-radius: 0 !important;
 }
 .reply,
-:root.op-background .postContainer.opContainer,
+:root.op-background .op,
 .dialog,
 .entry,
 .inline,

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -6,6 +6,9 @@ div.boardBanner,
 #menu,
 input:not(.jsColor),
 textarea,
+a.summary,
+.pages.cataloglink a,
+.pages strong>a,
 #qr-filename-container,
 #post-preview,
 .post-last,
@@ -48,12 +51,6 @@ body.is_catalog .button,
 .options-button,
 .tegaki-tb-btn {
   color: " + $SS.theme.linkColor.hex + " !important;
-}
-a.summary,
-.pages strong>a,
-input[value='Next'],
-input[value='Previous'] {
-  color: " + $SS.theme.textColor.hex + " !important;
 }
 #header-bar #notifications a {
   color: #ffffff !important;
@@ -179,8 +176,10 @@ body.is_catalog .panel,
 .options-button,
 .qr-link,
 .pages.cataloglink,
-.pages strong>a {
-  background:linear-gradient(rgb\(" + $SS.theme.mainColor.shiftRGB(15) + "),rgb(" + $SS.theme.mainColor.rgb + ")) !important;
+.pages strong>a,
+input[value='Next'],
+input[value='Previous'] {
+  background: linear-gradient(rgb\(" + $SS.theme.mainColor.shiftRGB(15) + "),rgb(" + $SS.theme.mainColor.rgb + ")) !important;
 }
 .options-button:hover,
 .import-input:hover + .options-button,
@@ -197,7 +196,9 @@ input[value='Previous']:hover {
 :root.vertical-qr #qr .move {
   background: rgb\(" + $SS.theme.mainColor.rgb + ");
 }
-input:not(.jsColor),
+input[type=text]:not(.jsColor),
+input.field,
+#qr input,
 textarea,
 .riceCheck,
 #qr-filename-container,
@@ -211,7 +212,9 @@ input[type=checkbox],
 .riceCheck {
   background: rgb\(" + $SS.theme.inputColor.shiftRGB(25) + ") !important;
 }
-input:not(.jsColor):hover,
+input[type=text]:not(.jsColor):hover,
+input.field:hover,
+#qr input:hover,
 .riceCheck:hover,
 #qr-filename-container:hover,
 textarea:hover,
@@ -264,6 +267,10 @@ hr {
 :root.rounded-corners .fileThumb img:not(.full-image),
 :root.rounded-corners .catalog-thumb,
 :root.rounded-corners .dd-menu ul,
+:root.rounded-corners .pages.cataloglink,
+:root.rounded-corners .pages strong>a,
+:root.rounded-corners input[value='Next'],
+:root.rounded-corners input[value='Previous'],
 :root.rounded-corners.werkTyme .catalog-thread:not(:hover),
 :root.rounded-corners.werkTyme:not(.catalog-hover-expand) .catalog-thread,
 :root.rounded-corners.catalog-hover-expand .catalog-container:hover > .post,
@@ -326,7 +333,9 @@ input[value='Previous'] {
 a.quotelink.forwardlink, a.backlink.forwardlink {
   border-bottom: 1px dashed;
 }
-input:focus,
+input[type=text]:focus,
+input.field:focus,
+#qr input:focus,
 textarea:focus,
 #qr-filename-container:focus,
 #qr-filename-container.focus,

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -68,7 +68,7 @@ body.is_catalog .button:hover,
   color: " + $SS.theme.linkHColor.hex + " !important;
 }
 /* Header */
-#header-bar, 
+#header-bar,
 a.current {
   color: " + $SS.theme.headerColor.hex + " !important;
 }
@@ -131,7 +131,7 @@ s:hover .quote,
   color: rgba(" + $SS.theme.textColor.rgb + ",.4) !important;
 }
 ::-webkit-input-placeholder {
-  color:rgba(" + $SS.theme.textColor.rgb + ",.4) !important;
+  color: rgba(" + $SS.theme.textColor.rgb + ",.4) !important;
 }
 #qr .field::-moz-placeholder,
 ::-moz-placeholder,
@@ -188,14 +188,14 @@ body.is_catalog .panel,
 .dd-menu li:hover,
 input[value='Next']:hover,
 input[value='Previous']:hover {
-  background:rgb\(" + $SS.theme.mainColor.shiftRGB(15) + ");
+  background: rgb\(" + $SS.theme.mainColor.shiftRGB(15) + ");
 }
 .focused.entry {
-  background:rgb\(" + $SS.theme.mainColor.shiftRGB(10) + ") !important;
+  background: rgb\(" + $SS.theme.mainColor.shiftRGB(10) + ") !important;
 }
 .qr-link:hover,
 :root.vertical-qr #qr .move {
-  background:rgb\(" + $SS.theme.mainColor.rgb + ");
+  background: rgb\(" + $SS.theme.mainColor.rgb + ");
 }
 input:not(.jsColor),
 textarea,
@@ -227,11 +227,11 @@ hr {
   background-image: linear-gradient(to left, rgba(" + $SS.theme.unreadColor.rgb + ",0), rgb(" + $SS.theme.unreadColor.rgb + "), rgba(" + $SS.theme.unreadColor.rgb + ",0));
 }
 .inline {
-  background:rgba\(" + $SS.theme.mainColor.shiftRGB(-16) + ",.8)!important;
+  background: rgba\(" + $SS.theme.mainColor.shiftRGB(-16) + ",.8)!important;
 }
 :root.post-info .reply>.postInfo {
   background: rgba\(" + $SS.theme.mainColor.shiftRGB(-16) + ",.2);
-  border-bottom:1px solid rgb\(" + $SS.theme.mainColor.shiftRGB(4) + ");
+  border-bottom: 1px solid rgb\(" + $SS.theme.mainColor.shiftRGB(4) + ");
 }
 /* Borders */
 .reply,
@@ -246,7 +246,7 @@ hr {
 }
 :root.borders-none .reply,
 :root.borders-none.op-background .postContainer.opContainer {
-  border: none;
+  border: 0;
 }
 #menu,
 .catalog-thumb {
@@ -376,11 +376,11 @@ select:focus,
   rgba(0,0,0,.6) 0 0 2px;
 }
 .thumb {
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 5px rgba(0,0,0,.25);
 }
 #qr,
 #thread-watcher {
-  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 1px 1px 3px rgba(0,0,0,.1) !important;
 }
 /* Closed Threads */
 .closed {

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -205,7 +205,7 @@ select,
 .captcha-root,
 #t-root {
   background: " + $SS.theme.inputColor.hex + " !important;
-  transition: background .2s, color .2s, border-color .2s !important;
+  transition: background .2s, color .2s, border-color .2s, width .2s !important;
 }
 input[type=checkbox],
 .riceCheck {
@@ -298,8 +298,6 @@ input,
 textarea,
 .riceCheck,
 #qr-filename-container,
-#search-box,
-#index-search,
 .captcha-img,
 :root.vertical-qr #qr .move,
 #qr select,

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -112,7 +112,7 @@ s:hover .quote,
   text-shadow: none !important;
 }
 /* Backlinks */
-.backlink {
+.backlink, .backlink.deadlink {
   color: " + $SS.theme.blinkColor.hex + " !important;
 }
 :root.backlink-shadow .backlink {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -20,9 +20,6 @@ body {
 .expanded-image {
   position: relative;
 }
-div.post {
-  margin: 4px 0;
-}
 :root.force-indent .op {
   margin-left: -12px;
 }
@@ -51,7 +48,7 @@ div.post {
   margin: 0 !important;
 }
 /* Fit Expanded Images option */
-:root.fit-eximg:root.fit-height .full-image {
+:root.fit-eximg.fit-height .full-image {
   max-height: calc(100vh - 8rem) !important;
 }
 /* Fit Width option */
@@ -210,8 +207,7 @@ input[type=checkbox]:checked+.riceCheck::before {
   margin-left: 2px;
 }
 :root.fixed:not(.autohide):not(.bottom) #globalMessage {
-  margin-top: 10px !important;
-  margin-bottom: 20px !important;
+  margin: 10px 0 20px !important;
 }
 .globalMessage, h2, h3 {
   margin: auto;
@@ -251,8 +247,8 @@ hr {
 }
 /* Board Title */
 .boardBanner .boardTitle {
-  cursor:default;
-  letter-spacing:-2px;
+  cursor: default;
+  letter-spacing: -2px;
   padding-top: .1em;
 }
 /* Banner */
@@ -275,8 +271,7 @@ hr {
   transition: opacity .3s ease-out 0s;
 }
 :root.banner-opacity #bannerCnt:hover {
-  opacity: 1.0 !important;
-  transition: opacity .3s ease-in 0s;
+  opacity: 1;
 }
 /* Pages */
 .pages strong>a,
@@ -287,8 +282,7 @@ input[value='Previous'] {
 .pages strong>a:hover,
 input[value='Next']:hover,
 input[value='Previous']:hover {
-  opacity: .7 !important;
-  transition: opacity .3s ease-in 0s;
+  opacity: .7;
 }
 .pagelist {
   margin-left: 18px;
@@ -364,8 +358,7 @@ body.board_f #delform .fileText {
 }
 :root.ad-opacity .center img:hover,
 :root.ad-opacity .danbo-slot:hover {
-  opacity: 1.0 !important;
-  transition: opacity .3s ease-in 0s;
+  opacity: 1;
 }
 /* Navlinks */
 body.is_index div.navLinks {
@@ -396,7 +389,7 @@ body.is_thread div.navLinks:not(.navLinksBot) {
   transition: opacity .3s ease-out 0s;
 }
 :root.thumb-opacity .fileThumb img:not(.full-image):hover {
-  opacity: 1.0;
+  opacity: 1;
 }
 /* Selection Lists */
 select {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -236,8 +236,9 @@ hr {
   width: 100%;
 }
 #unread-line {
-  margin-top: -3px !important;
-  margin-bottom: -3px !important;
+  margin-top: " + (($SS.conf["Margin Between Replies"] < -2) ? ($SS.conf["Margin Between Replies"] - 1) : -3) + "px !important;
+  margin-bottom: " + (($SS.conf["Margin Between Replies"] < -2) ? -5 : -3) + "px !important;
+  position: relative;
 }
 /* Scroll Marker */
 :root:not(.autohide) #scroll-marker {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -106,27 +106,25 @@ body {
 :root.reply-fit-width .reply .container {
   padding-right: 5px;
 }
-:root.reply-fit-width.fit-postmenu .postInfo > .menu-button {
+:root.reply-fit-width.fit-postmenu .postInfo>.menu-button {
   float: right !important;
 }
 .menu-button + .container:not(:empty),
 .container {
   margin-left: 4px !important;
 }
-:root.reply-fit-width .post .menu-button {
+:root.reply-fit-width.fit-postmenu .post .menu-button {
   margin-left: 0;
   position: relative;
   left: 5px;
 }
-:root.reply-fit-width .post .menu-button {
+:root.reply-fit-width.fit-postmenu .post .menu-button {
   opacity: 0;
+  transition: opacity .3s ease-out 0s;
 }
-:root.reply-fit-width .post:not(:hover) .menu-button {
-  transition: opacity .3s ease-out 0s !important;
-}
-:root.reply-fit-width .post:hover .menu-button {
+:root.reply-fit-width.fit-postmenu .post:hover .menu-button {
   opacity: 1;
-  transition: opacity .3s ease-in .1s !important;
+  transition: opacity .3s ease-in .1s;
 }
 /* Code Tags */
 .prettyprint {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -20,6 +20,9 @@ body {
 .expanded-image {
   position: relative;
 }
+:root.op-background .op {
+  padding: 4px 0;
+}
 :root.force-indent .op {
   margin-left: -12px;
 }
@@ -28,9 +31,10 @@ body {
   content: '';
   display: block;
 }
-.thread>.replyContainer,
-.threadContainer>.replyContainer {
-  margin-bottom:" + $SS.conf["Margin Between Replies"] + "px !important;
+.thread>.replyContainer:not(.thread>.postContainer:last-of-type),
+.threadContainer>.replyContainer,
+:root.op-background .thread>.opContainer:not(.thread>.postContainer:last-of-type) {
+  margin-bottom: " + $SS.conf["Margin Between Replies"] + "px !important;
 }
 .inline {
   margin-left: 13px !important;
@@ -44,8 +48,30 @@ body {
 .postMessage {
   margin: " + $SS.conf["Margin Post Message"] + " !important;
 }
-.postContainer.opContainer {
-  margin: 0 !important;
+/* Index thread summary */
+:root.op-background:not(.float-summary) .summary:not(.summary-bottom, .preview-summary) {
+  display: block;
+  padding-top: " + (($SS.conf["Margin Between Replies"] < -2) ? (($SS.conf["Margin Between Replies"] * -1) - 3) : 0) + "px;
+  margin-top: " + (($SS.conf["Margin Between Replies"] > 0) ? (($SS.conf["Margin Between Replies"] * -1) + 1) : -3) + "px;
+}
+:root.op-background:not(.float-summary) body.board_vg .summary:last-of-type:not(.preview-summary),
+.summary-bottom {
+  display: block;
+  padding-top: 0;
+  margin-top: -3px;
+}
+:root.float-summary .summary:not(.preview-summary),
+:root.float-summary.op-background body.board_vg .summary:last-of-type:not(.summary-bottom, .preview-summary) {
+  margin-top: -" + (($SS.conf["Font Size"] < 13) ? 19 : ($SS.conf["Font Size"] + 6)) + "px;
+  float: right;
+  padding-right: 5px;
+  position: relative;
+}
+:root.float-summary.op-background .summary:not(.summary-bottom, .preview-summary) {
+  margin-top: " + (($SS.conf["Margin Between Replies"] <= 0) ? (($SS.conf["Margin Between Replies"] * -1) - (($SS.conf["Font Size"] < 13) ? 19 : ($SS.conf["Font Size"] + 6))) : -($SS.conf["Margin Between Replies"] + (($SS.conf["Font Size"] < 13) ? 15 : ($SS.conf["Font Size"] + 2)))) + "px;
+}
+:root.float-summary.bottom-backlinks body.is_index .op:not(#qp .op, .inline .op):has(.container:not(:empty)) {
+  padding-bottom: " + ($SS.conf["Font Size"] + 2) + "px;
 }
 /* Fit Expanded Images option */
 :root.fit-eximg.fit-height .full-image {
@@ -369,11 +395,14 @@ body.board_f #delform .fileText {
   opacity: 1;
 }
 /* Navlinks */
+#ctrl-top,
 body.is_index div.navLinks {
-  padding: 5px 0;
+  padding-top: 5px;
+  margin-bottom: 5px;
 }
 body.is_thread div.navLinks:not(.navLinksBot) {
-  padding: .4% 0 .4% 0;
+  padding-top: .4%;
+  margin-bottom: .4%;
 }
 .navLinks.navLinksBot.desktop {
   margin-bottom: 5px;

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -273,12 +273,17 @@ hr {
   opacity: 1;
 }
 /* Pages */
-.pages strong>a,
+.pages.cataloglink {
+  margin-left: 12px;
+}
+.pages.cataloglink a,
 input[value='Next'],
 input[value='Previous'] {
-  border-radius: 3px;
+  font-weight: 700;
+  transition: opacity .3s ease-in 0s;
 }
 .pages strong>a:hover,
+.pages.cataloglink a:hover,
 input[value='Next']:hover,
 input[value='Previous']:hover {
   opacity: .7;
@@ -293,6 +298,10 @@ input[value='Previous']:hover {
 .pages a {
   padding: 5px 10px;
   margin-left: -1px;
+}
+.pages strong>a {
+  padding-top: 3px;
+  transition: opacity .3s ease-in 0s;
 }
 .next,
 .prev {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -70,7 +70,7 @@ body {
 :root.float-summary.op-background .summary:not(.summary-bottom, .preview-summary) {
   margin-top: " + (($SS.conf["Margin Between Replies"] <= 0) ? (($SS.conf["Margin Between Replies"] * -1) - (($SS.conf["Font Size"] < 13) ? 19 : ($SS.conf["Font Size"] + 6))) : -($SS.conf["Margin Between Replies"] + (($SS.conf["Font Size"] < 13) ? 15 : ($SS.conf["Font Size"] + 2)))) + "px;
 }
-:root.float-summary.bottom-backlinks body.is_index .op:not(#qp .op, .inline .op):has(.container:not(:empty)) {
+:root.float-summary.bottom-backlinks body.is_index .thread:has(.summary) .op:not(#qp .op, .inline .op):has(.container:not(:empty)) {
   padding-bottom: " + ($SS.conf["Font Size"] + 2) + "px;
 }
 /* Fit Expanded Images option */

--- a/src/css/Icons.css
+++ b/src/css/Icons.css
@@ -54,6 +54,18 @@
 :root.backlink-icon .backlink.inlined:hover {
   opacity: 1 !important;
 }
+/*Add icon to posts with replies when using 4chan X's Bottom Backlinks setting*/
+:root.bottom-backlinks.bottom-bl-icon .post:has(>.container:not(:empty))>.postInfo::after {
+  content: '';
+  background-image: url(\"data:image/svg+xml," + $SS.theme.icons.bubble + "\");
+  display: inline-block;
+  width: " + $SS.conf["Font Size"] + "px;
+  height: " + $SS.conf["Font Size"] + "px;
+  margin: -1px 0;
+}
+:root.bottom-backlinks.bottom-bl-icon.reply-fit-width.fit-postmenu .post:has(>.container:not(:empty))>.postInfo::after {
+  margin-left: 4px;
+}
 /* From 4chanSS */
 img[title=Closed],
 img[title=Sticky],

--- a/src/css/Original.css
+++ b/src/css/Original.css
@@ -197,6 +197,9 @@ input[value='Previous'] {
   top: 135px;
   right: 10px;
 }
+.identityIcon {
+  margin-bottom: -3px;
+}
 #ctrl-top {
   margin: 5px 0 5px 0;
 }

--- a/src/css/Original.css
+++ b/src/css/Original.css
@@ -190,7 +190,7 @@ span.hide-announcement {
 /* Index Navigation */
 input[value='Next'],
 input[value='Previous'] {
-  padding: 4px;
+  padding: 4px 13px;
 }
 /* Other */
 #navlinks {

--- a/src/css/Original.css
+++ b/src/css/Original.css
@@ -49,7 +49,6 @@ div.op.post div.file .fileThumb {
   margin-left: 13px !important;
   margin-bottom: 2px !important;
 }
-
 /* Padding according to header position */
 .fixed.bottom-header body.is_thread {
   padding-bottom: 0em;
@@ -182,12 +181,10 @@ span.hide-announcement {
 }
 .fixed.bottom-header body.is_index .bottomCtrl.desktop,
 .fixed.bottom-header body.is_thread .bottomCtrl.desktop {
-  float: right;
   margin-bottom: 35px;
 }
 .fixed.top-header body.is_thread .bottomCtrl.desktop,
 .fixed.top-header body.is_index .bottomCtrl.desktop {
-  float: right;
   margin-bottom: 8px;
 }
 /* Index Navigation */

--- a/src/css/Original.css
+++ b/src/css/Original.css
@@ -200,9 +200,6 @@ input[value='Previous'] {
 .identityIcon {
   margin-bottom: -3px;
 }
-#ctrl-top {
-  margin: 5px 0 5px 0;
-}
 :root.isLight img[src*='//boards.4chan.org/js/jsMath/fonts/'] {
   filter: invert(100%);
   -webkit-filter: invert(100%);

--- a/src/script.js
+++ b/src/script.js
@@ -109,6 +109,7 @@
             "Reduce Thumbnail Opacity": [false, "Reduces opacity of thumbnails."],
             "Backlink Icons": [false, "Use icons for backlinks instead of text."],
             "Backlink Shadow": [false, "Add a shadow to the backlink text."],
+            "Mark Posts with Bottom Backlinks": [false, "When using 4chan X's Bottom Backlinks setting, adds an icon to the post info to better identify when a post is quoted."],
             "Borders": [
                 2, "Changes which sides of replies have borders.", [{
                     name: "Normal (4chan default)",
@@ -2592,6 +2593,7 @@
                 $("html").optionClass("Invert Spoiler", true, "alt-spoiler");
                 $("html").optionClass("Backlink Icons", true, "backlink-icon");
                 $("html").optionClass("Backlink Shadow", true, "backlink-shadow");
+                $("html").optionClass("Mark Posts with Bottom Backlinks", true, "bottom-bl-icon");
                 $("html").optionClass("Show 4chan Pass Users", true, "no-pu");
                 $("html").optionClass("Show 4chan Pass Login", true, "pass-login");
                 $("html").optionClass("Fit Expanded Images", true, "fit-eximg");
@@ -3280,6 +3282,8 @@
                     "<path fill='rgb(" + this.textColor.rgb + ")' d='M14.615,4.928c0.487-0.986,1.284-0.986,1.771,0l2.249,4.554c0.486,0.986,1.775,1.923,2.864,2.081l5.024,0.73c1.089,0.158,1.335,0.916,0.547,1.684l-3.636,3.544c-0.788,0.769-1.28,2.283-1.095,3.368l0.859,5.004c0.186,1.085-0.459,1.553-1.433,1.041l-4.495-2.363c-0.974-0.512-2.567-0.512-3.541,0l-4.495,2.363c-0.974,0.512-1.618,0.044-1.432-1.041l0.858-5.004c0.186-1.085-0.307-2.6-1.094-3.368L3.93,13.977c-0.788-0.768-0.542-1.525,0.547-1.684l5.026-0.73c1.088-0.158,2.377-1.095,2.864-2.081L14.615,4.928z'/></svg>",
                 backlink: "<svg viewBox='0 0 30 30' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg'>" +
                     "<path fill='rgb(" + this.blinkColor.rgb + ")' d='M12.981,9.073V6.817l-12.106,6.99l12.106,6.99v-2.422c3.285-0.002,9.052,0.28,9.052,2.269c0,2.78-6.023,4.263-6.023,4.263v2.132c0,0,13.53,0.463,13.53-9.823C29.54,9.134,17.952,8.831,12.981,9.073z'/></svg>",
+                bubble: "<svg viewBox='0 0 30 30' preserveAspectRatio='true' xmlns='http://www.w3.org/2000/svg'>" +
+                    "<path fill='rgb(" + this.blinkColor.rgb + ")' d='M16,5.333c-7.732,0-14,4.701-14,10.5c0,1.982,0.741,3.833,2.016,5.414L2,25.667l5.613-1.441c2.339,1.317,5.237,2.107,8.387,2.107c7.732,0,14-4.701,14-10.5C30,10.034,23.732,5.333,16,5.333z'/></svg>",
                 quickReply: "<svg viewBox='0 0 30 30' preserveAspectRatio='xMidYMid meet' height='16' width='16' xmlns='http://www.w3.org/2000/svg'>" +
                     "<path fill='rgb(" + this.headerColor.rgb + ")' d='M16,5.333c-7.732,0-14,4.701-14,10.5c0,1.982,0.741,3.833,2.016,5.414L2,25.667l5.613-1.441c2.339,1.317,5.237,2.107,8.387,2.107c7.732,0,14-4.701,14-10.5C30,10.034,23.732,5.333,16,5.333z'/></svg>",
                 threadClosed: "<svg viewBox='0 0 30 30' preserveAspectRatio='xMidYMid meet' height='16' width='16' xmlns='http://www.w3.org/2000/svg'>" +

--- a/src/script.js
+++ b/src/script.js
@@ -105,6 +105,7 @@
             "Indent OP": [true, "Indents the OP instead of touching the screen."],
             "Allow Wrapping Around OP": [false, "Allow for replies to wrap around OP instead of being forced onto their own line."],
             "OP Background": [true, "Give OP a background similar to a reply."],
+            "Thread Summary in OP": [false, "Moves the index thread summary to the bottom right of OP."],
             "Recolor Even Replies": [false, "Makes every other post a darker color. If Quote Threading is enabled darkens every root reply."],
             "Reduce Thumbnail Opacity": [false, "Reduces opacity of thumbnails."],
             "Backlink Icons": [false, "Use icons for backlinks instead of text."],
@@ -2605,6 +2606,7 @@
                 $("html").optionClass("Indent OP", false, "force-indent");
                 $("html").optionClass("Allow Wrapping Around OP", false, "force-wrapping");
                 $("html").optionClass("OP Background", true, "op-background");
+                $("html").optionClass("Thread Summary in OP", true, "float-summary");
                 $("html").optionClass("Expanding Form Inputs", true, "expand-inputs");
                 $("html").optionClass("Animated Transition", true, "qr-transition");
                 $("html").optionClass("Show Header Background Gradient", true, "header-gradient");


### PR DESCRIPTION
Here's some things I've been working on the last few weeks. Much of this was designed with Margin Between Replies set to None or lower in mind. I throughly tested it as much as I could with both X and XT, but I may have still missed a few things. Let me know what you think, since this is a bit more intricate than what I've submitted before.

- Change how OP Background is added to the OP, targeting .op instead of .postContainer.opContainer. This makes OP identical to how replies are styled.
- Adjust padding and margin to top thread navigation, thread summary and inside OP to account for these changes.
- OP is now affected by Margin Between Replies when OP Background is enabled.
- Margin Between Replies will no longer affect the last post in thread. This allows for proper spacing between threads on the index.
- Add "Thread Summary in OP" option. This will move the thread summary on the index to the bottom right corner of OP instead of under it. Adapts to font size, and works on /vg/'s replyless index.
- Make the thread unread line more adaptable to when Margin Between Replies is set to None or Overlapping Borders. Unread line will now overlap the post borders instead of pusing apart the posts.
- Add "Mark Posts with Bottom Backlinks" option. This will add an icon to posts with backlinks while using 4chan X's Bottom Backlinks setting. (Adapted from an anon's theme >>>/g/104086265)
- Adjust how inputs are styled, better targeting text based ones. This adjustment is for the next change to work.
- Finish styling native index nav buttons. Index buttons added to rounded corners option.

Fixes:
- Add .identityIcon.
- Dead backlink becoming uncolored in XT.
- Add width to input transitions. This fixes the search boxes on the index not having the expanding animation.
- Remove the search box IDs from border color styling. This fixes the search boxes not having their focus border.
- Fix positioning and hover hiding happening when Fit Width is on, but Fit Post Menu is off.