### PR TITLE
Rewrite how font family is handled

### DIFF
--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -134,16 +134,10 @@ s:hover .quote,
 }
 .pun,
 #qr-no-file,
+::placeholder,
 #t-load:disabled,
 :root.single-captcha #t-next:not(.is-ready),
 :root:not(.single-captcha) #t-next:disabled {
-  color: rgba(var(--sc-textColor-rgb),.4) !important;
-}
-::-webkit-input-placeholder {
-  color: rgba(var(--sc-textColor-rgb),.4) !important;
-}
-#qr .field::-moz-placeholder,
-::-moz-placeholder {
   color: rgba(var(--sc-textColor-rgb),.4) !important;
 }
 /* Backgrounds */

--- a/src/css/Fonts.css
+++ b/src/css/Fonts.css
@@ -63,23 +63,23 @@ textarea[name="com"],
 #tegaki,
 div.next,
 form.pageSwitcherForm > input[type="submit"] {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + " !important;
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
   font-size: " + $SS.conf["Font Size"] + "px !important;
 }
 #full-board-list a,
 #custom-board-list,
 a.qr-link {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + " !important;
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
   font-size: " + $SS.conf["Font Size"] + "px !important;
 }
 #qr .field::-moz-placeholder,
 ::-moz-placeholder {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + " !important;
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
   font-size: " + $SS.conf["Font Size"] + "px !important;
 }
 #qr .field::webkit-input-placeholder,
 ::webkit-input-placeholder {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + " !important;
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
   font-size: " + $SS.conf["Font Size"] + "px !important;
 }
 .backlink {
@@ -100,7 +100,7 @@ a.qr-link {
 #fourchanx-settings,
 #fourchanx-settings input,
 #fourchanx-settings select {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ";
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif;
   font-size: " + (($SS.conf["Font Size"] >= 15) ? 15 : 13) + "px !important;
 }
 #qr-file-button,
@@ -113,7 +113,7 @@ input,
 :root #t-load,
 :root #t-next,
 :root #t-task {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ";
+  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif;
   font-size: " + $SS.conf["UI Font Size"] + "px !important;
 }
 #qr-file-button,

--- a/src/css/Fonts.css
+++ b/src/css/Fonts.css
@@ -54,7 +54,6 @@ body,
 #qr select[data-name="thread"],
 :root #t-desc,
 textarea[name="com"],
-#qr .field::placeholder, 
 ::placeholder,
 #menu .entry,
 #boardList,
@@ -69,16 +68,6 @@ form.pageSwitcherForm > input[type="submit"] {
 #full-board-list a,
 #custom-board-list,
 a.qr-link {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
-  font-size: " + $SS.conf["Font Size"] + "px !important;
-}
-#qr .field::-moz-placeholder,
-::-moz-placeholder {
-  font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
-  font-size: " + $SS.conf["Font Size"] + "px !important;
-}
-#qr .field::webkit-input-placeholder,
-::webkit-input-placeholder {
   font-family: " + $SS.formatFont($SS.conf["Font Family"]) + ", sans-serif !important;
   font-size: " + $SS.conf["Font Size"] + "px !important;
 }

--- a/src/css/Options.css
+++ b/src/css/Options.css
@@ -86,11 +86,10 @@
   float: left !important;
   margin-right: 5px !important;
 }
-select[name='Font Family']>option {
-  max-width:150px;
-  overflow:hidden;
-  white-space:nowrap;
-  text-overflow:ellipsis;
+/*Remove font datalist dropdown arrow in Chrome*/
+input[name='Font Family']::-webkit-calendar-picker-indicator,
+input[name='Font Family']::-webkit-list-button {
+  display: none !important;
 }
 .suboption::before {
   border-bottom:1px solid rgba(0,0,0,.1);

--- a/src/script.js
+++ b/src/script.js
@@ -215,7 +215,7 @@
         ],
         ":: Fonts": ["header", ""],
         "Font Family": [
-            "sans-serif", "Set the default font family.", [{
+            "sans-serif", "Set the default font family. Please make sure the font is installed locally and the font family name is correct when using a custom font.", [{
                 name: "Default",
                 value: "sans-serif"
             }, {
@@ -1934,10 +1934,16 @@
                                 "</span><input" + (val ? " checked" : "") + " name='" + key + "' type=checkbox></label>");
                         } else if (Array.isArray(defaultConfig[key][2])) // select
                         {
-                            var opts = defaultConfig[key][2],
-                                cFonts = [],
-                                html = ["<label class=option title=\"" + des + "\"><span class='option-title'>" + key + "</span>",
-                                "<select name='" + key + "'" + (defaultConfig[key][3] === true ? " has-suboption" : "") + ">"];
+                            var opts = defaultConfig[key][2];
+                            if (key === "Font Family") {
+                                html = ["<label class=option title=\"" + des + "\"><span class='option-title'>" + key + "</span>" +
+                                    "<input type='text' name='" + key + "' list='" + key + "' value='" + val + "')>" +
+                                    "<datalist id='" + key + "'>"];
+                            }
+                            else {
+                                html = ["<label class=option title=\"" + des + "\"><span class='option-title'>" + key + "</span>" +
+                                    "<select name='" + key + "'" + (defaultConfig[key][3] === true ? " has-suboption" : "") + ">"];
+                            }
 
                             for (var i = 0, MAX = opts.length; i < MAX; ++i) {
                                 var name, value;
@@ -1948,16 +1954,10 @@
                                 } else
                                     name = value = opts[i];
 
-                                if (key === "Font Family") cFonts.push(value);
-
-                                html.push("<option" + (key === "Font Family" ? " style=\"font-family:" + $SS.formatFont(value) + "!important\"" : "") +
-                                    " value='" + value + "'" + (value == val ? " selected" : "") + ">" + name + "</option>");
+                                html.push("<option value='" + value + "'" + (value == val ? " selected" : "") + ">" + name + "</option>");
                             }
 
-                            if (key === "Font Family" && cFonts.indexOf($SS.conf["Font Family"]) == -1)
-                                html.push("<option style=\"font-family:" + $SS.formatFont($SS.conf["Font Family"]) + "!important\" value='" + $SS.conf["Font Family"] + "' selected>" + $SS.conf["Font Family"] + "</option>");
-
-                            html.push("</select></label>");
+                            html.push((key === "Font Family" ? "</datalist>" : "</select>") + "</label>");
                             optionsHTML.push(html.join(""));
                         } else if (key === "Font Size") {
                             optionsHTML.push("<label class='option visible' title=\"" + des + "\"><span class='option-title'>" + key + "</span>" +


### PR DESCRIPTION
This is probably the point where my PRs are gonna start really butting heads with you.

I added this to my branch on Oneechan a while back, while trying to figure out what to do about font customizability. After some research, using a datalist seemed like the best middle ground, so I went an rewrote it the best I could.

I'm still trying to parse through all these new rapid fire changes you're adding in, but I think I adjusted it enough to work in StyleChan without issue. At least, it is on my end. I probably missed something still.

The only thing I wasn't able to do was to blank the value on clicking the input, to make it easier to type in or select a new font. While an onclick event would work well enough, sticking an event listenter somewhere in there would probably be better. I don't trust myself enough to add it though.